### PR TITLE
Keyboard_ESP32C3: fix i2c setup as peripheral

### DIFF
--- a/examples/Keyboard_ESP32C3/Keyboard_ESP32C3.ino
+++ b/examples/Keyboard_ESP32C3/Keyboard_ESP32C3.ino
@@ -127,7 +127,7 @@ void setup()
 
     Serial.setDebugOutput(true);
     Wire.onRequest(onRequest);
-    Wire.begin((uint8_t)I2C_DEV_ADDR, SDA, SCL);
+    Wire.begin((uint8_t)I2C_DEV_ADDR, SDA, SCL, 0);
 
     Serial.println("Starting keyboard work!");
     pinMode(keyborad_BL_PIN, OUTPUT);


### PR DESCRIPTION
for some reason with my version of platformio, the call to

	Wire.begin((uint8_t)I2C_DEV_ADDR, SDA, SCL);

will resolve to controller setup instead of peripheral setup, and wrong parameters for it:

	entry 0x403cc710
	[    44][I][esp32-hal-i2c.c:75] i2cInit(): Initialising I2C Master: sda=85 scl=2 freq=10
	[    44][E][esp32-hal-i2c.c:88] i2cInit(): i2c_param_config failed
	Starting keyboard work!

to call the correct overloaded function for peripheral setup, add 0 to the call for the default frequency. with this, peripheral setup works and the keyboard can communicate with the t-deck esp32s3 successfully:

	entry 0x403cc710
	[    44][I][esp32-hal-i2c-slave.c:234] i2cSlaveInit(): Initialising I2C Slave: sda=2 scl=10 freq=100000, addr=0x55
	[    44][D][esp32-hal-i2c-slave.c:486] i2c_slave_set_frequency(): Fifo thresholds: rx_fifo_full = 28, tx_fifo_empty = 4
	Starting keyboard work!