### PR TITLE
Added alternative to set WiFi params via environment variables

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,6 +36,9 @@ examples
 8. Click (→) to upload firmware
 9. Click (plug symbol) to monitor serial output
 
+Optional:
+
+You can upload the assets contents for the speaker demo, using the "Upload Filesystem Image" on PlatformIO menu.
 
 ### ArduinoIDE
 

--- a/examples/UnitTest/UnitTest.ino
+++ b/examples/UnitTest/UnitTest.ino
@@ -264,7 +264,7 @@ static void wifi_event_cb(WiFiEvent_t event)
 void setupWiFi()
 {
     WiFi.onEvent(wifi_event_cb);
-    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    WiFi.begin(WIFI_SSID, WIFI_PASS);
 
     configTzTime(DEFAULT_TIMEZONE, NTP_SERVER1, NTP_SERVER2);
     // set notification call-back function

--- a/examples/UnitTest/config.h
+++ b/examples/UnitTest/config.h
@@ -5,8 +5,8 @@
 #define WIFI_SSID             "You WIFI SSID"
 #endif
 
-#ifndef WIFI_PASSWORD
-#define WIFI_PASSWORD         "You WIFI PASSWORD"
+#ifndef WIFI_PASS
+#define WIFI_PASS         "You WIFI PASSWORD"
 #endif
 
 #define NTP_SERVER1           "pool.ntp.org"

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,6 +7,11 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
+
+[wifi]
+ssid = ${sysenv.PIO_WIFI_SSID}         
+password = ${sysenv.PIO_WIFI_PASSWORD}
+
 [platformio]
 ; default_envs =  T-Keyboard
 ; src_dir = examples/Keyboard_ESP32C3
@@ -44,14 +49,14 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = 115200
 build_flags = 
-    -DBOARD_HAS_PSRAM
-
+    -DBOARD_HAS_PSRAM=1
+    -DCORE_DEBUG_LEVEL=5
     ; Enable UARDUINO_ USB_ CDC_ ON_ BOOT will start printing and wait for terminal access during startup
     -DARDUINO_USB_CDC_ON_BOOT=1
-
+    '-DWIFI_SSID="${wifi.ssid}"'
+    '-DWIFI_PASS="${wifi.password}"'
     ; Enable UARDUINO_USB_CDC_ON_BOOT will turn off printing and will not block when using the battery
     ; -UARDUINO_USB_CDC_ON_BOOT
-
-    -DDISABLE_ALL_LIBRARY_WARNINGS
+    ; -DDISABLE_ALL_LIBRARY_WARNINGS
 
 


### PR DESCRIPTION
## Summary

With these PR you are able to set the WiFi credentials via two environment variables like this:

```bash
export PIO_WIFI_SSID="Your wifi ssid"
export PIO_WIFI_PASSWOR="Your wifi password"
```

