### PR TITLE
Fix ledc error reported over serial on boot.

### DIFF
--- a/examples/Keyboard_ESP32C3/Keyboard_ESP32C3.ino
+++ b/examples/Keyboard_ESP32C3/Keyboard_ESP32C3.ino
@@ -199,8 +199,8 @@ void setup()
 
     Serial.println("Starting keyboard work!");
 
-    ledcAttachPin(keyboard_BL_PIN, KB_BRIGHTNESS_CH);
     ledcSetup(KB_BRIGHTNESS_CH, KB_BRIGHTNESS_FREQ, KB_BRIGHTNESS_RES);
+    ledcAttachPin(keyboard_BL_PIN, KB_BRIGHTNESS_CH);
     ledcWrite(KB_BRIGHTNESS_CH, KB_BRIGHTNESS_BOOT_DUTY);
 
     Serial.println("4");


### PR DESCRIPTION
When booting the T-Deck and monitoring the keyboards output via serial it reports the following error:

`E (229) ledc: ledc_get_duty(740): LEDC is not initialized`

This fix simply ensures `ledcSetup` comes before `ledcAttachPin`.